### PR TITLE
Update kuenm_cal.R

### DIFF
--- a/R/kuenm_cal.R
+++ b/R/kuenm_cal.R
@@ -315,6 +315,7 @@ kuenm_cal <- function(occ.joint, occ.tra, M.var.dir, batch, out.dir, max.memory 
       r_wd <- getwd() # real working directory
       setwd(maxent.path) # change temporally the working directory
 
+    ###  system(paste("sudo chmod -R a+rwx ",r_wd,sep=""), wait=TRUE)
       system(paste("bash", batfile_path), wait = wait)
 
     } else {

--- a/R/kuenm_cal.R
+++ b/R/kuenm_cal.R
@@ -187,7 +187,7 @@ kuenm_cal <- function(occ.joint, occ.tra, M.var.dir, batch, out.dir, max.memory 
   ##Environmental variables sets
   m <- dir(M.var.dir)
   ms <- paste(gsub("/", dl, paste(getwd(), M.var.dir, sep = sl)), sl, m, sep = "")
-  env <- paste("environmentallayers=", paste("\"", ms, "\"", sep = ""), sep = "")
+  env <- paste("-z environmentallayers=", paste("\"", ms, "\"", sep = ""), sep = "")
 
   ##Species occurrences
   oc <- occ.joint

--- a/R/kuenm_mod.R
+++ b/R/kuenm_mod.R
@@ -236,7 +236,7 @@ kuenm_mod <- function(occ.joint, M.var.dir, out.eval, batch, rep.n = 10, rep.typ
   ##Environmental calibration variables sets
   env <- vector()
   for (i in 1:length(var.dir)) {
-    env[i] <- paste("environmentallayers=", var.dir[i], sep = "")
+    env[i] <- paste("-z environmentallayers=", var.dir[i], sep = "")
   }
 
   ##Species occurrences
@@ -297,21 +297,21 @@ kuenm_mod <- function(occ.joint, M.var.dir, out.eval, batch, rep.n = 10, rep.typ
     }
 
     if(ext.type == "ext_clam") {
-      mid.com <- "extrapolate=true doclamp=true responsecurves=true"
+      mid.com <- "extrapolate=true doclamp=true responsecurves=false"
       ext.nam <- "_EC"
     }
     if(ext.type == "ext") {
-      mid.com <- "extrapolate=true doclamp=false responsecurves=true"
+      mid.com <- "extrapolate=true doclamp=false responsecurves=false"
       ext.nam <- "_E"
     }
     if(ext.type == "no_ext") {
-      mid.com <- "extrapolate=false doclamp=false responsecurves=true"
+      mid.com <- "extrapolate=false doclamp=false responsecurves=false"
       ext.nam <- "_NE"
     }
     if(ext.type == "all") {
-      mid.com <- c("extrapolate=true doclamp=true responsecurves=true",
-                   "extrapolate=true doclamp=false responsecurves=true",
-                   "extrapolate=false doclamp=false responsecurves=true")
+      mid.com <- c("extrapolate=true doclamp=true responsecurves=false",
+                   "extrapolate=true doclamp=false responsecurves=false",
+                   "extrapolate=false doclamp=false responsecurves=false")
       ext.nam <- c("_EC", "_E", "_NE")
     }
 
@@ -322,7 +322,7 @@ kuenm_mod <- function(occ.joint, M.var.dir, out.eval, batch, rep.n = 10, rep.typ
       w.clamp <- "writemess=false"
     }
   }else {
-    mid.com <- "extrapolate=false doclamp=false writeclampgrid=false writemess=false responsecurves=true"
+    mid.com <- "extrapolate=false doclamp=false writeclampgrid=false writemess=false responsecurves=false"
   }
 
   ##Jackknife
@@ -353,7 +353,7 @@ kuenm_mod <- function(occ.joint, M.var.dir, out.eval, batch, rep.n = 10, rep.typ
   a.fea <- "autofeature=false"
 
   ##Other maxent settings
-  fin.com <- "warnings=false visible=false redoifexists autorun\n"
+  fin.com <- "plots=false pictures=false outputformat=raw warnings=false visible=false redoifexists autorun\n"
 
   #####
   #Final code


### PR DESCRIPTION
Added -z to env <- paste("-z environmentallayers=", paste("\"", ms, "\"", sep = ""), sep = "")

The parameter -z tells the program not to start the user interface, so that maxent runs in command line mode only. This is necessary to run in Linux server environments without having maxent call a display X11(), otherwise maxent.jar returns an error "Exception in thread "main" java.awt.AWTError: Can't connect to X11 window server using ':0' as the value of the DISPLAY variable."